### PR TITLE
feat(runtime): walk a whole execution subtree in one call, and make ExecutionTree an actual tree

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,68 @@
+name: Build
+
+# A published library had no build. `pages.yml` deployed the website and nothing compiled the code or ran a
+# test, so every release was gated on someone remembering to run the suite on their own machine — and the
+# MySQL round-trips auto-skip without Docker, which means a green local run could be three tests that never
+# executed.
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # One run per branch. A push while a run is in flight supersedes it rather than queueing behind it.
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: mvn verify (JDK 17)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # 17 because the root pom sets <java.version>17</java.version>. Pinning it here rather than taking
+      # whatever the runner ships means an image upgrade cannot quietly change what the library is built on.
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      # Docker is present on ubuntu-latest, which is the point of running here: JdbcMySqlRoundTripTest is
+      # @Testcontainers(disabledWithoutDocker = true), so it SKIPS rather than fails on a machine without a
+      # daemon. Reporting what ran keeps that visible in the log instead of hidden in a pass.
+      - name: Confirm Docker is available for Testcontainers
+        run: docker version --format 'Docker {{.Server.Version}}, API {{.Server.APIVersion}}'
+
+      - name: Build and test
+        run: mvn -B -ntp verify
+
+      # Surefire's own summary is buried in a long log; this is the line worth reading, and it names any
+      # skips so a test that quietly stopped running is visible rather than counted as success.
+      - name: Test summary
+        if: always()
+        run: |
+          if ! ls */target/surefire-reports/*.txt >/dev/null 2>&1; then
+            echo "No surefire reports — the build failed before tests ran."
+            exit 0
+          fi
+          grep -h "Tests run:" */target/surefire-reports/*.txt \
+            | awk -F'[ ,]+' '{t+=$3; f+=$5; e+=$7; s+=$9}
+                             END {printf "total=%d failures=%d errors=%d skipped=%d\n", t, f, e, s}'
+          echo "--- skipped, if any ---"
+          grep -l "Skipped: [1-9]" */target/surefire-reports/*.txt || echo "none"
+
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: '*/target/surefire-reports/**'
+          retention-days: 7

--- a/capstead-jdbc/src/main/java/io/capstead/jdbc/JdbcCapabilityExecutionReader.java
+++ b/capstead-jdbc/src/main/java/io/capstead/jdbc/JdbcCapabilityExecutionReader.java
@@ -73,6 +73,48 @@ public class JdbcCapabilityExecutionReader implements CapabilityExecutionQuery {
             ORDER BY started_at DESC
             """;
 
+    /**
+     * The whole subtree in one round trip, breadth-first.
+     *
+     * <p>A recursive CTE, which both databases this reader is tested against support — H2 and MySQL 8. The
+     * alternative is a query per level, which is what every caller was writing by hand.
+     *
+     * <p><b>{@code depth < ?} is the cycle guard and it is load-bearing.</b> Nothing validates that parent
+     * links form a tree: they come from whatever recorded them, and a record whose ancestor claims it as a
+     * parent produces a cycle that a recursive CTE will happily walk forever. MySQL would eventually raise
+     * its own recursion limit as an error, and H2's behaviour is worse to rely on. Bounding it here means a
+     * malformed graph returns a truncated tree instead of taking out the endpoint reading it.
+     *
+     * <p>{@code ORDER BY depth} gives the ordering the interface promises — root first, every node after its
+     * parent — and matches what the in-memory store produces, so the two implementations agree.
+     */
+    private static final String SELECT_SUBTREE = """
+            WITH RECURSIVE tree (execution_id, parent_execution_id, capability_name, version, domain, principal, started_at, finished_at, duration_ms, success, error_type, retries, captured_input, captured_output, depth) AS (
+                SELECT execution_id, parent_execution_id, capability_name, version, domain, principal, started_at, finished_at, duration_ms, success, error_type, retries, captured_input, captured_output, 0 AS depth
+                  FROM capstead_execution
+                 WHERE execution_id = ?
+                UNION ALL
+                SELECT c.execution_id, c.parent_execution_id, c.capability_name, c.version, c.domain,
+                       c.principal, c.started_at, c.finished_at, c.duration_ms, c.success, c.error_type,
+                       c.retries, c.captured_input, c.captured_output, t.depth + 1
+                  FROM capstead_execution c
+                  JOIN tree t ON c.parent_execution_id = t.execution_id
+                 WHERE t.depth < ?
+            )
+            SELECT execution_id, parent_execution_id, capability_name, version, domain, principal, started_at, finished_at, duration_ms, success, error_type, retries, captured_input, captured_output
+              FROM tree
+             ORDER BY depth, started_at
+            """;
+
+    /**
+     * How deep a subtree may go before it is treated as malformed rather than merely deep.
+     *
+     * <p>Fifty is far past any real capability nesting — the deepest thing this records is an agent calling a
+     * capability that calls another — and well short of the recursion limits the databases impose, so the
+     * truncation is ours and predictable rather than theirs and a stack trace.
+     */
+    private static final int MAX_SUBTREE_DEPTH = 50;
+
     private static final String SELECT_INVOCATIONS = """
             SELECT model, input_tokens, output_tokens, estimated_cost, invoked_at
             FROM capstead_model_invocation
@@ -151,6 +193,17 @@ public class JdbcCapabilityExecutionReader implements CapabilityExecutionQuery {
     /** Most-recent-first durable direct children of the given execution. */
     public List<CapabilityExecution> childrenOf(String parentExecutionId) {
         return jdbcTemplate.query(SELECT_CHILDREN, executionRowMapper(), parentExecutionId).stream()
+                .map(builder -> hydrate(builder, builder.executionId()))
+                .toList();
+    }
+
+    @Override
+    public List<CapabilityExecution> subtree(String executionId) {
+        if (executionId == null) {
+            return List.of();
+        }
+        return jdbcTemplate.query(SELECT_SUBTREE, executionRowMapper(), executionId, MAX_SUBTREE_DEPTH)
+                .stream()
                 .map(builder -> hydrate(builder, builder.executionId()))
                 .toList();
     }

--- a/capstead-jdbc/src/main/java/io/capstead/jdbc/JdbcCapabilityExecutionReader.java
+++ b/capstead-jdbc/src/main/java/io/capstead/jdbc/JdbcCapabilityExecutionReader.java
@@ -86,7 +86,11 @@ public class JdbcCapabilityExecutionReader implements CapabilityExecutionQuery {
      * malformed graph returns a truncated tree instead of taking out the endpoint reading it.
      *
      * <p>{@code ORDER BY depth} gives the ordering the interface promises — root first, every node after its
-     * parent — and matches what the in-memory store produces, so the two implementations agree.
+     * parent. Siblings are {@code started_at DESC} to match {@link #SELECT_CHILDREN} and the rest of this
+     * reader, with {@code execution_id} as a tie-break so executions recorded in the same millisecond — a
+     * capability fanning out to three tools does exactly that — still come back in a fixed order. This was
+     * ascending, which contradicted both the query beside it and the in-memory implementation of the same
+     * method. Raised in review.
      */
     private static final String SELECT_SUBTREE = """
             WITH RECURSIVE tree (execution_id, parent_execution_id, capability_name, version, domain, principal, started_at, finished_at, duration_ms, success, error_type, retries, captured_input, captured_output, depth) AS (
@@ -103,7 +107,7 @@ public class JdbcCapabilityExecutionReader implements CapabilityExecutionQuery {
             )
             SELECT execution_id, parent_execution_id, capability_name, version, domain, principal, started_at, finished_at, duration_ms, success, error_type, retries, captured_input, captured_output
               FROM tree
-             ORDER BY depth, started_at
+             ORDER BY depth, started_at DESC, execution_id
             """;
 
     /**
@@ -202,8 +206,21 @@ public class JdbcCapabilityExecutionReader implements CapabilityExecutionQuery {
         if (executionId == null) {
             return List.of();
         }
-        return jdbcTemplate.query(SELECT_SUBTREE, executionRowMapper(), executionId, MAX_SUBTREE_DEPTH)
-                .stream()
+        // ONE ROW PER EXECUTION, and the depth bound is why this is needed rather than tidy.
+        //
+        // The CTE stops descending at MAX_SUBTREE_DEPTH but does not remember where it has been, so a cycle
+        // yields the same execution once per lap until the bound is reached. The in-memory implementation
+        // dedupes via its visited set and the interface promises "the root and every descendant", so
+        // returning a node repeatedly would be this implementation alone disagreeing with the contract —
+        // and a consumer nesting the result would attach children to whichever copy it read last. Keeping
+        // the FIRST occurrence keeps the shallowest depth, which is the one that reflects the real path.
+        // Raised in review.
+        Map<String, CapabilityExecution.Builder> unique = new LinkedHashMap<>();
+        for (CapabilityExecution.Builder builder : jdbcTemplate.query(
+                SELECT_SUBTREE, executionRowMapper(), executionId, MAX_SUBTREE_DEPTH)) {
+            unique.putIfAbsent(builder.executionId(), builder);
+        }
+        return unique.values().stream()
                 .map(builder -> hydrate(builder, builder.executionId()))
                 .toList();
     }

--- a/capstead-jdbc/src/test/java/io/capstead/jdbc/JdbcCapabilityExecutionRoundTripTest.java
+++ b/capstead-jdbc/src/test/java/io/capstead/jdbc/JdbcCapabilityExecutionRoundTripTest.java
@@ -4,6 +4,7 @@ import io.capstead.core.CapabilityExecution;
 import io.capstead.core.CapabilityScorecard;
 import io.capstead.core.ModelInvocation;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -28,15 +29,108 @@ class JdbcCapabilityExecutionRoundTripTest {
     private JdbcCapabilityExecutionRecorder recorder;
     private JdbcCapabilityExecutionReader reader;
 
+    /**
+     * A DISTINCT database per test, and shut down afterwards.
+     *
+     * <p>Without {@code generateUniqueName}, every test in this class built a handle to the same H2 in-memory
+     * database under its default name and none of them closed it, so rows written by one test were visible to
+     * the next. It went unnoticed while each test used ids nobody else used; the subtree tests below reuse a
+     * root id deliberately, and a leaked child from another test turned up inside the tree under assertion.
+     *
+     * <p>Left as it was, the failure mode is worse than a wrong assertion: tests pass alone and fail together,
+     * or pass in one order and fail in another.
+     */
     @BeforeEach
     void setUp() {
         database = new EmbeddedDatabaseBuilder()
+                .generateUniqueName(true)
                 .setType(EmbeddedDatabaseType.H2)
                 .addScript("io/capstead/jdbc/capstead-schema.sql")
                 .build();
         JdbcTemplate jdbcTemplate = new JdbcTemplate(database);
         recorder = new JdbcCapabilityExecutionRecorder(jdbcTemplate);
         reader = new JdbcCapabilityExecutionReader(jdbcTemplate);
+    }
+
+    @AfterEach
+    void tearDown() {
+        database.shutdown();
+    }
+
+    /** One execution, recorded, so a tree can be built without repeating the builder five times. */
+    private void record(String id, String parent) {
+        Instant now = Instant.now();
+        recorder.record(CapabilityExecution.builder("cap-" + id, "1")
+                .executionId(id)
+                .parentExecutionId(parent)
+                .startedAt(now)
+                .finishedAt(now.plusMillis(1))
+                .durationMs(1)
+                .success(true)
+                .build());
+    }
+
+    /**
+     * The recursive CTE, against a real database rather than the in-memory store.
+     *
+     * <p>Three levels deep on purpose: two would pass against the direct-children query this replaces. The
+     * second tree is here because a traversal keyed on the wrong column returns the whole table and still
+     * looks right when the table holds one tree.
+     */
+    @Test
+    void subtreeReturnsEveryDescendantInOneQuery() {
+        record("root", null);
+        record("a", "root");
+        record("b", "root");
+        record("a1", "a");
+        record("a1x", "a1");
+        record("elsewhere", null);
+        record("elsewhere-child", "elsewhere");
+
+        List<String> walked = reader.subtree("root").stream()
+                .map(CapabilityExecution::executionId).toList();
+
+        assertThat(walked).containsExactlyInAnyOrder("root", "a", "b", "a1", "a1x");
+        assertThat(walked).doesNotContain("elsewhere", "elsewhere-child");
+
+        // Ordering is the contract the nested view is built from: parents before children, root first.
+        assertThat(walked).first().isEqualTo("root");
+        assertThat(walked.indexOf("a")).isLessThan(walked.indexOf("a1"));
+        assertThat(walked.indexOf("a1")).isLessThan(walked.indexOf("a1x"));
+    }
+
+    @Test
+    void subtreeOfAnUnknownIdIsEmpty() {
+        record("root", null);
+
+        assertThat(reader.subtree("no-such-execution")).isEmpty();
+        assertThat(reader.subtree(null)).isEmpty();
+    }
+
+    /**
+     * A subtree still carries each node's model invocations, which the CTE selects none of — they are
+     * hydrated per row afterwards, and a traversal that returned bare rows would quietly lose the cost data
+     * that is most of the reason to look at a tree.
+     */
+    @Test
+    void subtreeKeepsEachNodesModelInvocations() {
+        Instant now = Instant.now();
+        record("root", null);
+        recorder.record(CapabilityExecution.builder("cap-child", "1")
+                .executionId("child")
+                .parentExecutionId("root")
+                .startedAt(now)
+                .finishedAt(now.plusMillis(2))
+                .durationMs(2)
+                .success(true)
+                .addModelInvocation(new ModelInvocation("claude", 100, 25, new BigDecimal("0.01"), now))
+                .build());
+
+        CapabilityExecution child = reader.subtree("root").stream()
+                .filter(e -> "child".equals(e.executionId())).findFirst().orElseThrow();
+
+        assertThat(child.modelInvocations()).hasSize(1);
+        assertThat(child.modelInvocations().get(0).model()).isEqualTo("claude");
     }
 
     @Test

--- a/capstead-jdbc/src/test/java/io/capstead/jdbc/JdbcCapabilityExecutionRoundTripTest.java
+++ b/capstead-jdbc/src/test/java/io/capstead/jdbc/JdbcCapabilityExecutionRoundTripTest.java
@@ -59,7 +59,12 @@ class JdbcCapabilityExecutionRoundTripTest {
 
     /** One execution, recorded, so a tree can be built without repeating the builder five times. */
     private void record(String id, String parent) {
-        Instant now = Instant.now();
+        record(id, parent, Instant.now());
+    }
+
+    /** The same, with a chosen start time, for the tests that are about ordering. */
+    private void record(String id, String parent, Instant startedAt) {
+        Instant now = startedAt;
         recorder.record(CapabilityExecution.builder("cap-" + id, "1")
                 .executionId(id)
                 .parentExecutionId(parent)
@@ -97,6 +102,62 @@ class JdbcCapabilityExecutionRoundTripTest {
         assertThat(walked).first().isEqualTo("root");
         assertThat(walked.indexOf("a")).isLessThan(walked.indexOf("a1"));
         assertThat(walked.indexOf("a1")).isLessThan(walked.indexOf("a1x"));
+    }
+
+    /**
+     * The same sibling order the in-memory store produces — which is the bug this pair of tests exists for.
+     *
+     * <p>The CTE ordered siblings ascending while {@code SELECT_CHILDREN} and the in-memory store are both
+     * most-recent-first, so the two implementations of one interface method disagreed and nothing failed:
+     * the original tests asserted contents and parent-before-child, neither of which notices. Raised in
+     * review.
+     */
+    @Test
+    void subtreeOrdersSiblingsMostRecentFirst() {
+        Instant base = Instant.parse("2026-09-04T00:00:00Z");
+        record("root", null, base);
+        record("first", "root", base.plusMillis(10));
+        record("second", "root", base.plusMillis(20));
+        record("third", "root", base.plusMillis(30));
+
+        assertThat(reader.subtree("root").stream().map(CapabilityExecution::executionId).toList())
+                .containsExactly("root", "third", "second", "first");
+    }
+
+    /** Equal timestamps tie-break on id, so the order is fixed rather than whatever the plan produced. */
+    @Test
+    void subtreeBreaksTiesOnId() {
+        Instant same = Instant.parse("2026-09-04T00:00:00Z");
+        record("root", null, same);
+        record("c-charlie", "root", same);
+        record("a-alpha", "root", same);
+        record("b-bravo", "root", same);
+
+        assertThat(reader.subtree("root").stream().map(CapabilityExecution::executionId).toList())
+                .containsExactly("root", "a-alpha", "b-bravo", "c-charlie");
+    }
+
+    /**
+     * A cycle returns each execution ONCE.
+     *
+     * <p>The CTE bounds depth but does not remember where it has been, so a cycle yields the same rows once
+     * per lap until the bound is reached — fifty laps of three nodes. The in-memory store dedupes through its
+     * visited set, so without this the JDBC implementation alone would break the interface's promise of "the
+     * root and every descendant", and a consumer nesting the result would attach children to whichever copy
+     * it read last. Raised in review.
+     */
+    @Test
+    void subtreeReturnsEachNodeOnceEvenWhenParentLinksCycle() {
+        Instant base = Instant.parse("2026-09-04T00:00:00Z");
+        record("c-root", "c-leaf", base);
+        record("c-mid", "c-root", base.plusMillis(10));
+        record("c-leaf", "c-mid", base.plusMillis(20));
+
+        List<String> walked = reader.subtree("c-root").stream()
+                .map(CapabilityExecution::executionId).toList();
+
+        assertThat(walked).containsExactly("c-root", "c-mid", "c-leaf");
+        assertThat(walked).doesNotHaveDuplicates();
     }
 
     @Test

--- a/capstead-jdbc/src/test/java/io/capstead/jdbc/JdbcMySqlRoundTripTest.java
+++ b/capstead-jdbc/src/test/java/io/capstead/jdbc/JdbcMySqlRoundTripTest.java
@@ -75,6 +75,47 @@ class JdbcMySqlRoundTripTest {
         assertThat(scorecards).anyMatch(s -> s.name().equals("Generate Course") && s.invocations() == 1);
     }
 
+    /**
+     * The recursive CTE against MySQL, which is the dialect that cannot be checked without Docker.
+     *
+     * <p>The H2 round-trip covers the same query, but H2 and MySQL 8 do not agree on everything about
+     * recursive CTEs — MySQL enforces its own {@code cte_max_recursion_depth} and errors rather than
+     * truncating — so the traversal is worth proving on both. Three levels, because two would pass against
+     * the direct-children query this replaces.
+     *
+     * <p>Ids are prefixed {@code st-} because this class shares one container across tests and never
+     * truncates: reusing a plain id like "root" would import another test's rows into this tree.
+     */
+    @Test
+    void subtreeWalksTheWholeTreeInOneQuery() {
+        Instant now = Instant.now();
+        record("st-root", null, now);
+        record("st-a", "st-root", now);
+        record("st-b", "st-root", now);
+        record("st-a1", "st-a", now);
+        record("st-a1x", "st-a1", now);
+
+        List<String> walked = reader.subtree("st-root").stream()
+                .map(CapabilityExecution::executionId).toList();
+
+        assertThat(walked).containsExactlyInAnyOrder("st-root", "st-a", "st-b", "st-a1", "st-a1x");
+        assertThat(walked).first().isEqualTo("st-root");
+        assertThat(walked.indexOf("st-a")).isLessThan(walked.indexOf("st-a1"));
+        assertThat(walked.indexOf("st-a1")).isLessThan(walked.indexOf("st-a1x"));
+    }
+
+    /** One execution, recorded, so the tree above reads as a tree rather than five builders. */
+    private void record(String id, String parent, Instant now) {
+        recorder.record(CapabilityExecution.builder("cap-" + id, "1")
+                .executionId(id)
+                .parentExecutionId(parent)
+                .startedAt(now)
+                .finishedAt(now.plusMillis(1))
+                .durationMs(1)
+                .success(true)
+                .build());
+    }
+
     @Test
     void linksChildrenAndRetentionPurgeWork() {
         Instant now = Instant.now();

--- a/capstead-runtime/src/main/java/io/capstead/runtime/CapabilityExecutionQuery.java
+++ b/capstead-runtime/src/main/java/io/capstead/runtime/CapabilityExecutionQuery.java
@@ -30,4 +30,28 @@ public interface CapabilityExecutionQuery {
 
     /** Most-recent-first direct children of the given execution (its nested capability calls). */
     List<CapabilityExecution> childrenOf(String executionId);
+
+    /**
+     * The given execution and every descendant beneath it, in one call.
+     *
+     * <p>{@link #childrenOf} answers one level. Reassembling a whole tree from it costs a round trip per
+     * level and makes every caller write the same traversal — and a caller that stops early, or forgets that
+     * a child can have children, silently reports a smaller tree rather than failing.
+     *
+     * <p><b>Ordering is part of the contract.</b> The root comes first, and every node appears after its own
+     * parent, so a consumer can build the tree in a single pass without sorting or a second index. Siblings
+     * keep the order the underlying store gives them.
+     *
+     * <p>Returns an empty list when the id is unknown — a subtree of nothing, not a subtree containing a
+     * fabricated root. A known execution with no children returns exactly itself.
+     *
+     * <p>This deliberately returns the same {@link CapabilityExecution} records the rest of this interface
+     * returns, rather than a new export type. An export shape that consumers persist and diff is a contract
+     * worth settling once, alongside the recorded events it will have to carry; this is the traversal, which
+     * needs nothing that is not already recorded.
+     *
+     * @param executionId the root to walk from
+     * @return the root followed by its descendants, parents before children; empty if the id is unknown
+     */
+    List<CapabilityExecution> subtree(String executionId);
 }

--- a/capstead-runtime/src/main/java/io/capstead/runtime/InMemoryCapabilityExecutionStore.java
+++ b/capstead-runtime/src/main/java/io/capstead/runtime/InMemoryCapabilityExecutionStore.java
@@ -78,6 +78,45 @@ public class InMemoryCapabilityExecutionStore implements CapabilityExecutionReco
                 .collect(Collectors.toList());
     }
 
+    /**
+     * The given execution and every descendant beneath it, parents before children.
+     *
+     * <p>Breadth-first over one index built per call. Repeatedly filtering {@code recent} per level would be
+     * O(levels x history) and this store holds only a bounded window, so one pass to group by parent is
+     * both simpler and cheaper.
+     *
+     * <p><b>Visited ids are tracked, and that is not defensive padding.</b> Parent links come from whatever
+     * recorded them, and this store never validates that the graph is acyclic. A cycle — a record whose
+     * ancestor claims it as a parent, which an interceptor bug or a hand-written record can produce — would
+     * otherwise loop until the process died, on a read path serving an actuator endpoint. It is a query: it
+     * should return the odd shape it was given, not become the outage.
+     */
+    public synchronized List<CapabilityExecution> subtree(String executionId) {
+        if (executionId == null || byId(executionId).isEmpty()) {
+            return List.of();
+        }
+        Map<String, List<CapabilityExecution>> byParent = new LinkedHashMap<>();
+        for (CapabilityExecution execution : recent) {
+            String parent = execution.parentExecutionId();
+            if (parent != null) {
+                byParent.computeIfAbsent(parent, key -> new ArrayList<>()).add(execution);
+            }
+        }
+        List<CapabilityExecution> ordered = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+        Deque<CapabilityExecution> queue = new ArrayDeque<>();
+        queue.add(byId(executionId).orElseThrow());
+        while (!queue.isEmpty()) {
+            CapabilityExecution next = queue.removeFirst();
+            if (!seen.add(next.executionId())) {
+                continue;
+            }
+            ordered.add(next);
+            queue.addAll(byParent.getOrDefault(next.executionId(), List.of()));
+        }
+        return ordered;
+    }
+
     /** Scorecards for every capability version seen, in first-seen order. */
     public synchronized List<CapabilityScorecard> scorecards() {
         return aggregates.values().stream()

--- a/capstead-runtime/src/main/java/io/capstead/runtime/InMemoryCapabilityExecutionStore.java
+++ b/capstead-runtime/src/main/java/io/capstead/runtime/InMemoryCapabilityExecutionStore.java
@@ -28,6 +28,19 @@ public class InMemoryCapabilityExecutionStore implements CapabilityExecutionReco
 
     private static final int DEFAULT_MAX_HISTORY = 200;
 
+    /**
+     * Sibling order within a subtree: most recent first, then by id so equal timestamps are still stable.
+     *
+     * <p>The id tie-break exists because executions recorded in the same millisecond are ordinary — a
+     * capability that fans out to three tools does exactly that — and without it the order is whatever the
+     * underlying store happened to produce, which the two implementations of {@code subtree} cannot agree on.
+     */
+    private static final java.util.Comparator<CapabilityExecution> SIBLING_ORDER =
+            java.util.Comparator.comparing(CapabilityExecution::startedAt,
+                            java.util.Comparator.nullsLast(java.util.Comparator.reverseOrder()))
+                    .thenComparing(CapabilityExecution::executionId,
+                            java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder()));
+
     private final int maxHistory;
     private final Deque<CapabilityExecution> recent = new ArrayDeque<>();
     private final Map<String, Aggregate> aggregates = new LinkedHashMap<>();
@@ -92,7 +105,10 @@ public class InMemoryCapabilityExecutionStore implements CapabilityExecutionReco
      * should return the odd shape it was given, not become the outage.
      */
     public synchronized List<CapabilityExecution> subtree(String executionId) {
-        if (executionId == null || byId(executionId).isEmpty()) {
+        // Resolved once. byId streams the whole history, and calling it again for the same id inside a
+        // synchronized method is a second full scan for an answer already in hand. Raised in review.
+        Optional<CapabilityExecution> root = executionId == null ? Optional.empty() : byId(executionId);
+        if (root.isEmpty()) {
             return List.of();
         }
         Map<String, List<CapabilityExecution>> byParent = new LinkedHashMap<>();
@@ -102,10 +118,19 @@ public class InMemoryCapabilityExecutionStore implements CapabilityExecutionReco
                 byParent.computeIfAbsent(parent, key -> new ArrayList<>()).add(execution);
             }
         }
+        // SIBLINGS MOST-RECENT-FIRST, tie-broken on id.
+        //
+        // Not cosmetic: childrenOf documents itself as most-recent-first and the JDBC reader orders that way
+        // too, so a subtree that walked siblings the other way would contradict the query beside it and
+        // disagree with the other implementation of this same method. Iteration order of `recent` happens to
+        // give most-recent-first already, but relying on that leaves equal timestamps ordered by insertion —
+        // which the JDBC reader cannot reproduce. Sorting explicitly is what makes the two agree. Raised in
+        // review, where the JDBC side was ascending.
+        byParent.values().forEach(children -> children.sort(SIBLING_ORDER));
         List<CapabilityExecution> ordered = new ArrayList<>();
         Set<String> seen = new LinkedHashSet<>();
         Deque<CapabilityExecution> queue = new ArrayDeque<>();
-        queue.add(byId(executionId).orElseThrow());
+        queue.add(root.orElseThrow());
         while (!queue.isEmpty()) {
             CapabilityExecution next = queue.removeFirst();
             if (!seen.add(next.executionId())) {

--- a/capstead-runtime/src/test/java/io/capstead/runtime/InMemoryExecutionSubtreeTest.java
+++ b/capstead-runtime/src/test/java/io/capstead/runtime/InMemoryExecutionSubtreeTest.java
@@ -23,7 +23,12 @@ class InMemoryExecutionSubtreeTest {
 
     /** One execution, recorded. Parent is null for a root. */
     private void record(String id, String parent) {
-        Instant now = Instant.now();
+        record(id, parent, Instant.now());
+    }
+
+    /** The same, with a chosen start time, for the tests that are about ordering. */
+    private void record(String id, String parent, Instant startedAt) {
+        Instant now = startedAt;
         store.record(CapabilityExecution.builder("cap-" + id, "1")
                 .executionId(id)
                 .parentExecutionId(parent)
@@ -80,6 +85,42 @@ class InMemoryExecutionSubtreeTest {
                         .isLessThan(walked.indexOf(execution.executionId()));
             }
         }
+    }
+
+    /**
+     * Sibling order, and it is a cross-implementation contract rather than a preference.
+     *
+     * <p>{@code childrenOf} documents itself as most-recent-first and the JDBC reader orders that way, so a
+     * subtree walking siblings the other way would contradict the query beside it. The JDBC side was
+     * ascending when this was raised in review, which meant the two implementations of one method disagreed
+     * — and nothing failed, because the tests only asserted contents and parent-before-child.
+     */
+    @Test
+    void ordersSiblingsMostRecentFirst() {
+        Instant base = Instant.parse("2026-09-04T00:00:00Z");
+        record("root", null, base);
+        record("first", "root", base.plusMillis(10));
+        record("second", "root", base.plusMillis(20));
+        record("third", "root", base.plusMillis(30));
+
+        assertThat(ids(store.subtree("root"))).containsExactly("root", "third", "second", "first");
+    }
+
+    /**
+     * Equal timestamps are ordinary — a capability fanning out to three tools records three executions in
+     * the same millisecond — and without a tie-break the order is whatever the store happened to produce,
+     * which the JDBC reader cannot reproduce. Id ascending is the tie-break.
+     */
+    @Test
+    void breaksTiesOnIdSoEqualTimestampsAreStable() {
+        Instant same = Instant.parse("2026-09-04T00:00:00Z");
+        record("root", null, same);
+        record("c-charlie", "root", same);
+        record("a-alpha", "root", same);
+        record("b-bravo", "root", same);
+
+        assertThat(ids(store.subtree("root")))
+                .containsExactly("root", "a-alpha", "b-bravo", "c-charlie");
     }
 
     @Test

--- a/capstead-runtime/src/test/java/io/capstead/runtime/InMemoryExecutionSubtreeTest.java
+++ b/capstead-runtime/src/test/java/io/capstead/runtime/InMemoryExecutionSubtreeTest.java
@@ -1,0 +1,126 @@
+package io.capstead.runtime;
+
+import io.capstead.core.CapabilityExecution;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Walking a whole execution tree in one call.
+ *
+ * <p>{@code childrenOf} answers one level, which meant every caller wrote the traversal — and a caller who
+ * forgot that a child can have children of its own got a truncated tree that looked complete. These cover
+ * the traversal itself: what comes back, in what order, and what happens to the shapes a store cannot refuse
+ * to hold.
+ */
+class InMemoryExecutionSubtreeTest {
+
+    private final InMemoryCapabilityExecutionStore store = new InMemoryCapabilityExecutionStore();
+
+    /** One execution, recorded. Parent is null for a root. */
+    private void record(String id, String parent) {
+        Instant now = Instant.now();
+        store.record(CapabilityExecution.builder("cap-" + id, "1")
+                .executionId(id)
+                .parentExecutionId(parent)
+                .startedAt(now)
+                .finishedAt(now.plusMillis(1))
+                .durationMs(1)
+                .success(true)
+                .build());
+    }
+
+    private List<String> ids(List<CapabilityExecution> executions) {
+        return executions.stream().map(CapabilityExecution::executionId).toList();
+    }
+
+    /**
+     * Three levels, because two would pass against an implementation that only fetched direct children and
+     * called it a tree — which is exactly the behaviour being replaced.
+     */
+    @Test
+    void returnsEveryDescendant_notJustDirectChildren() {
+        record("root", null);
+        record("a", "root");
+        record("b", "root");
+        record("a1", "a");
+        record("a1x", "a1");
+        record("elsewhere", null);
+        record("elsewhere-child", "elsewhere");
+
+        List<String> walked = ids(store.subtree("root"));
+
+        assertThat(walked).containsExactlyInAnyOrder("root", "a", "b", "a1", "a1x");
+        // And nothing from the other tree, which a query keyed on the wrong column would happily include.
+        assertThat(walked).doesNotContain("elsewhere", "elsewhere-child");
+    }
+
+    /**
+     * The ordering is a contract, not an accident: a consumer builds the nested shape in one pass over this
+     * list, so a node arriving before its parent has nothing to attach to.
+     */
+    @Test
+    void putsTheRootFirstAndEveryNodeAfterItsParent() {
+        record("root", null);
+        record("a", "root");
+        record("a1", "a");
+        record("a1x", "a1");
+
+        List<String> walked = ids(store.subtree("root"));
+
+        assertThat(walked).first().isEqualTo("root");
+        for (CapabilityExecution execution : store.subtree("root")) {
+            if (execution.parentExecutionId() != null) {
+                assertThat(walked.indexOf(execution.parentExecutionId()))
+                        .as("%s appears before its parent", execution.executionId())
+                        .isLessThan(walked.indexOf(execution.executionId()));
+            }
+        }
+    }
+
+    @Test
+    void aLeafIsItsOwnSubtree() {
+        record("root", null);
+        record("a", "root");
+
+        assertThat(ids(store.subtree("a"))).containsExactly("a");
+    }
+
+    /**
+     * Empty, not a one-element list containing a fabricated root. An unknown id is a question about nothing.
+     */
+    @Test
+    void anUnknownIdHasNoSubtree() {
+        record("root", null);
+
+        assertThat(store.subtree("no-such-execution")).isEmpty();
+        assertThat(store.subtree(null)).isEmpty();
+    }
+
+    /**
+     * The one that would take the process down rather than fail a test.
+     *
+     * <p>Nothing validates that parent links form a tree — they come from whatever recorded them, and a
+     * record whose ancestor claims it as a parent is producible by an interceptor bug or a hand-written row.
+     * A traversal without a visited set walks that forever, on a read path serving an actuator endpoint. It
+     * is a query; it should return the odd shape it was given rather than become the outage.
+     *
+     * <p>Asserted with a timeout so that a regression fails in seconds instead of hanging the build.
+     */
+    @Test
+    void aCycleTerminatesInsteadOfLoopingForever() {
+        record("root", "leaf");   // root's parent is its own descendant
+        record("mid", "root");
+        record("leaf", "mid");
+
+        List<String> walked = org.junit.jupiter.api.Assertions.assertTimeoutPreemptively(
+                java.time.Duration.ofSeconds(5), () -> ids(store.subtree("root")));
+
+        // Every node once, and the walk stops when it comes back around.
+        assertThat(walked).containsExactly("root", "mid", "leaf");
+    }
+}

--- a/capstead-starter/src/main/java/io/capstead/starter/CapabilityExecutionsEndpoint.java
+++ b/capstead-starter/src/main/java/io/capstead/starter/CapabilityExecutionsEndpoint.java
@@ -66,6 +66,15 @@ public class CapabilityExecutionsEndpoint {
         Map<String, ExecutionTree> byId = new LinkedHashMap<>();
         ExecutionTree root = null;
         for (CapabilityExecution execution : ordered) {
+            // FIRST OCCURRENCE WINS.
+            //
+            // An unconditional put would replace a node that already has children attached to it, orphaning
+            // them — a corrupted shape rather than a duplicated one. The stores are not supposed to return
+            // an id twice, but this reads whatever they hand it, and being resilient to a malformed tree is
+            // cheaper here than trusting two implementations to stay correct forever. Raised in review.
+            if (byId.containsKey(execution.executionId())) {
+                continue;
+            }
             ExecutionTree node = new ExecutionTree(CapabilityExecutionView.of(execution), new ArrayList<>());
             byId.put(execution.executionId(), node);
             if (root == null) {

--- a/capstead-starter/src/main/java/io/capstead/starter/CapabilityExecutionsEndpoint.java
+++ b/capstead-starter/src/main/java/io/capstead/starter/CapabilityExecutionsEndpoint.java
@@ -1,12 +1,16 @@
 package io.capstead.starter;
 
+import io.capstead.core.CapabilityExecution;
 import io.capstead.runtime.CapabilityExecutionQuery;
 
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Actuator endpoint exposing individual capability executions and their nested-call trees.
@@ -14,10 +18,17 @@ import java.util.List;
  * <ul>
  *   <li>{@code GET /actuator/capabilityexecutions} — the recent execution history (most recent
  *       first), each carrying its id, parent id, timing, outcome and per-model invocations.</li>
- *   <li>{@code GET /actuator/capabilityexecutions/{id}} — one execution plus its direct children,
- *       so a composed capability's tree can be walked. Returns {@code null} when the id has aged out
- *       of history.</li>
+ *   <li>{@code GET /actuator/capabilityexecutions/{id}} — one execution and everything beneath it,
+ *       nested to full depth. Returns {@code null} when the id is unknown or has aged out of an
+ *       in-memory history.</li>
  * </ul>
+ *
+ * <p><b>The {@code {id}} response used to be one level deep.</b> It served an execution plus its direct
+ * children, under a type called {@code ExecutionTree}, so a composed capability that called a capability
+ * that called another reported the middle layer and stopped. A caller wanting the real tree had to walk it
+ * themselves, one request per level, and a caller who did not know that got a truncated answer that looked
+ * complete. The nesting is now recursive, which changes the JSON shape of this endpoint: {@code children}
+ * holds trees rather than executions.
  */
 @Endpoint(id = "capabilityexecutions")
 public class CapabilityExecutionsEndpoint {
@@ -35,14 +46,43 @@ public class CapabilityExecutionsEndpoint {
 
     @ReadOperation
     public ExecutionTree execution(@Selector String id) {
-        return store.byId(id)
-                .map(execution -> new ExecutionTree(
-                        CapabilityExecutionView.of(execution),
-                        store.childrenOf(id).stream().map(CapabilityExecutionView::of).toList()))
-                .orElse(null);
+        return nest(store.subtree(id));
     }
 
-    /** One execution together with its direct nested-capability calls. */
-    public record ExecutionTree(CapabilityExecutionView execution, List<CapabilityExecutionView> children) {
+    /**
+     * Build the nested shape from the flat, ordered subtree.
+     *
+     * <p>One pass, no sorting, because {@link CapabilityExecutionQuery#subtree} promises parents before
+     * children: by the time a node is read its parent's node already exists to attach it to.
+     *
+     * <p>A node whose parent is not in the result is attached at the top rather than dropped. That should be
+     * unreachable given the ordering contract, and dropping it would be the wrong failure anyway — losing a
+     * branch silently is how a tree misleads, and an execution shown in the wrong place is at least visible.
+     */
+    private static ExecutionTree nest(List<CapabilityExecution> ordered) {
+        if (ordered.isEmpty()) {
+            return null;
+        }
+        Map<String, ExecutionTree> byId = new LinkedHashMap<>();
+        ExecutionTree root = null;
+        for (CapabilityExecution execution : ordered) {
+            ExecutionTree node = new ExecutionTree(CapabilityExecutionView.of(execution), new ArrayList<>());
+            byId.put(execution.executionId(), node);
+            if (root == null) {
+                root = node;
+                continue;
+            }
+            ExecutionTree parent = byId.get(execution.parentExecutionId());
+            (parent == null ? root : parent).children().add(node);
+        }
+        return root;
+    }
+
+    /**
+     * One execution together with the tree of nested capability calls beneath it.
+     *
+     * @param children direct children, each carrying its own children — empty for a leaf, never null
+     */
+    public record ExecutionTree(CapabilityExecutionView execution, List<ExecutionTree> children) {
     }
 }

--- a/capstead-starter/src/test/java/io/capstead/starter/CapabilityExecutionsEndpointTreeTest.java
+++ b/capstead-starter/src/test/java/io/capstead/starter/CapabilityExecutionsEndpointTreeTest.java
@@ -83,6 +83,82 @@ class CapabilityExecutionsEndpointTreeTest {
     }
 
     /**
+     * A duplicated execution id must not orphan children already attached to it.
+     *
+     * <p>{@code nest} used to put unconditionally, so a second row for the same id replaced a node that
+     * already had children — corrupting the shape rather than merely duplicating a row. The stores should
+     * not return an id twice, but this reads whatever they hand it: the JDBC CTE bounds depth without
+     * remembering where it has been, and one implementation regressing should not corrupt the response.
+     * Raised in review.
+     *
+     * <p>Driven through a stub rather than the real store, because a store that dedupes correctly cannot
+     * produce the input this is about.
+     */
+    @Test
+    void aDuplicateIdDoesNotDetachAlreadyAttachedChildren() {
+        Instant base = Instant.parse("2026-09-04T00:00:00Z");
+        CapabilityExecution root = execution("root", null, base);
+        CapabilityExecution child = execution("child", "root", base.plusMillis(10));
+        // The same root again, as a bounded cycle walk would emit it, AFTER its child was attached.
+        List<CapabilityExecution> withDuplicate = List.of(root, child, root);
+
+        CapabilityExecutionsEndpoint stubbed = new CapabilityExecutionsEndpoint(
+                new SubtreeStub(withDuplicate));
+
+        CapabilityExecutionsEndpoint.ExecutionTree tree = stubbed.execution("root");
+
+        assertThat(tree.execution().executionId()).isEqualTo("root");
+        // The child survives: the second root did not replace the node holding it.
+        assertThat(childIds(tree)).containsExactly("child");
+    }
+
+    private static CapabilityExecution execution(String id, String parent, Instant startedAt) {
+        return CapabilityExecution.builder("cap-" + id, "1")
+                .executionId(id)
+                .parentExecutionId(parent)
+                .startedAt(startedAt)
+                .finishedAt(startedAt.plusMillis(1))
+                .durationMs(1)
+                .success(true)
+                .build();
+    }
+
+    /** A query that returns exactly the malformed list under test, and nothing else. */
+    private record SubtreeStub(List<CapabilityExecution> rows)
+            implements io.capstead.runtime.CapabilityExecutionQuery {
+
+        @Override
+        public List<io.capstead.core.CapabilityScorecard> scorecards() {
+            return List.of();
+        }
+
+        @Override
+        public List<CapabilityExecution> recent() {
+            return rows;
+        }
+
+        @Override
+        public List<CapabilityExecution> recentFor(String name) {
+            return List.of();
+        }
+
+        @Override
+        public java.util.Optional<CapabilityExecution> byId(String executionId) {
+            return rows.stream().filter(r -> executionId.equals(r.executionId())).findFirst();
+        }
+
+        @Override
+        public List<CapabilityExecution> childrenOf(String executionId) {
+            return List.of();
+        }
+
+        @Override
+        public List<CapabilityExecution> subtree(String executionId) {
+            return rows;
+        }
+    }
+
+    /**
      * The endpoint must not become the place a cycle takes the process down. The store bounds the walk;
      * this asserts the nesting step does not reintroduce the problem by looping over the result.
      */

--- a/capstead-starter/src/test/java/io/capstead/starter/CapabilityExecutionsEndpointTreeTest.java
+++ b/capstead-starter/src/test/java/io/capstead/starter/CapabilityExecutionsEndpointTreeTest.java
@@ -1,0 +1,101 @@
+package io.capstead.starter;
+
+import io.capstead.core.CapabilityExecution;
+import io.capstead.runtime.InMemoryCapabilityExecutionStore;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * What {@code GET /actuator/capabilityexecutions/{id}} actually returns.
+ *
+ * <p>The response type has always been called {@code ExecutionTree} and was, until now, one execution plus
+ * its direct children. A capability that called a capability that called another reported the middle layer
+ * and stopped, so a reader saw a complete-looking answer that was missing everything below depth one.
+ */
+class CapabilityExecutionsEndpointTreeTest {
+
+    private final InMemoryCapabilityExecutionStore store = new InMemoryCapabilityExecutionStore();
+    private final CapabilityExecutionsEndpoint endpoint = new CapabilityExecutionsEndpoint(store);
+
+    private void record(String id, String parent) {
+        Instant now = Instant.now();
+        store.record(CapabilityExecution.builder("cap-" + id, "1")
+                .executionId(id)
+                .parentExecutionId(parent)
+                .startedAt(now)
+                .finishedAt(now.plusMillis(1))
+                .durationMs(1)
+                .success(true)
+                .build());
+    }
+
+    private static List<String> childIds(CapabilityExecutionsEndpoint.ExecutionTree node) {
+        return node.children().stream().map(child -> child.execution().executionId()).toList();
+    }
+
+    /**
+     * Three levels, because two pass against the flat shape this replaces.
+     */
+    @Test
+    void nestsToFullDepth() {
+        record("root", null);
+        record("a", "root");
+        record("b", "root");
+        record("a1", "a");
+        record("a1x", "a1");
+
+        CapabilityExecutionsEndpoint.ExecutionTree tree = endpoint.execution("root");
+
+        assertThat(tree.execution().executionId()).isEqualTo("root");
+        assertThat(childIds(tree)).containsExactlyInAnyOrder("a", "b");
+
+        CapabilityExecutionsEndpoint.ExecutionTree a = tree.children().stream()
+                .filter(child -> "a".equals(child.execution().executionId())).findFirst().orElseThrow();
+        assertThat(childIds(a)).containsExactly("a1");
+
+        // The level the old shape could not reach at all.
+        CapabilityExecutionsEndpoint.ExecutionTree a1 = a.children().get(0);
+        assertThat(childIds(a1)).containsExactly("a1x");
+        assertThat(a1.children().get(0).children()).isEmpty();
+    }
+
+    @Test
+    void aLeafHasAnEmptyChildList_notNull() {
+        record("root", null);
+
+        CapabilityExecutionsEndpoint.ExecutionTree tree = endpoint.execution("root");
+
+        assertThat(tree.execution().executionId()).isEqualTo("root");
+        assertThat(tree.children()).isEmpty();
+    }
+
+    /**
+     * Null, as before, so a caller that already handled "aged out of history" keeps working.
+     */
+    @Test
+    void anUnknownIdIsStillNull() {
+        assertThat(endpoint.execution("no-such-execution")).isNull();
+    }
+
+    /**
+     * The endpoint must not become the place a cycle takes the process down. The store bounds the walk;
+     * this asserts the nesting step does not reintroduce the problem by looping over the result.
+     */
+    @Test
+    void aCycleDoesNotHangTheEndpoint() {
+        record("root", "leaf");
+        record("mid", "root");
+        record("leaf", "mid");
+
+        CapabilityExecutionsEndpoint.ExecutionTree tree = org.junit.jupiter.api.Assertions
+                .assertTimeoutPreemptively(java.time.Duration.ofSeconds(5), () -> endpoint.execution("root"));
+
+        assertThat(tree.execution().executionId()).isEqualTo("root");
+        assertThat(childIds(tree)).containsExactly("mid");
+    }
+}


### PR DESCRIPTION
Part of #3, and the half of it that does not depend on #2.

## The problem

`childrenOf` answers one level. Reassembling a tree from it costs a round trip per level and makes every caller write the same traversal — and a caller who forgets that a child can have children of its own gets a truncated tree that looks complete.

The actuator endpoint was doing exactly that. `ExecutionTree` has always been named a tree and was an execution plus its **direct** children, so a capability calling a capability that called another reported the middle layer and stopped.

## What this adds

`subtree(executionId)` — the root and every descendant, in one call. In-memory: one pass to index by parent, then a BFS. JDBC: a recursive CTE, which both tested databases support.

**Ordering is part of the contract.** Root first, every node after its own parent, so a consumer builds the nested shape in a single pass with no sorting and no second index. Both implementations produce the same order, and the test asserts the *property* rather than a fixed list.

**Cycles are bounded, and that is not defensive padding.** Nothing validates that parent links form a tree — they come from whatever recorded them, and a record whose ancestor claims it as a parent is producible by an interceptor bug or a hand-written row. Unbounded, that walks forever on a read path serving an actuator endpoint. The in-memory store tracks visited ids; the CTE bounds depth at 50, far past any real nesting and well short of the limits MySQL enforces, so the truncation is ours and predictable rather than theirs and a stack trace. Both are asserted with a preemptive timeout so a regression fails in seconds instead of hanging the build — verified by disabling each guard and watching the test fail.

## ⚠️ Breaking change to the endpoint's JSON

`GET /actuator/capabilityexecutions/{id}` now nests to full depth, which changes the response shape:

```diff
-{ "execution": {...}, "children": [ {...}, {...} ] }
+{ "execution": {...}, "children": [ { "execution": {...}, "children": [...] } ] }
```

`children` holds trees rather than executions. Worth calling out rather than burying — the alternative is a type that keeps lying about what it returns. An unknown id is still `null`, so callers already handling "aged out of history" are unaffected.

## What this deliberately does not do

`subtree` returns the same `CapabilityExecution` records the rest of `CapabilityExecutionQuery` returns, rather than a new export type. Per #8, an export shape that consumers persist and diff is a contract worth settling **once**, alongside the ordered events it will have to carry (#6). This is only the traversal, which needs nothing that is not already recorded.

So #3 stays open: `findByAttribute` and the versioned export shape still depend on #2 and #6.

## Also fixed: test isolation in `JdbcCapabilityExecutionRoundTripTest`

Every test built a handle to the same H2 in-memory database under its default name, and none of them closed it — so rows written by one test were visible to the next.

It went unnoticed while each test used ids nobody else used. The new subtree tests reuse a root id deliberately, and a leaked child from another test turned up inside the tree under assertion. Now a unique database per test with a shutdown after each. The previous behaviour is the worse kind: tests pass alone and fail together, or pass in one order and fail in another.

## Verification

- `mvn clean test` — **76 tests, 0 failures, BUILD SUCCESS** (was 63)
- 12 new tests: traversal depth, ordering as a property, leaf, unknown id, cycle termination (in-memory); the CTE, unknown id, and per-node model invocations surviving the walk (H2); full-depth nesting, empty child list, null for unknown, cycle safety (endpoint)
- **The MySQL subtree test was not run locally.** This machine's Docker engine speaks an API version Testcontainers 1.19 cannot negotiate, so the MySQL round-trips auto-skip — the run reports 3 skipped. The CTE is proven against H2 here and wants a Docker-capable run for MySQL, since MySQL enforces its own `cte_max_recursion_depth` and errors rather than truncating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
