### PR TITLE
ci(site): let the Pages workflow create the site it deploys to

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,8 +28,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # enablement: true creates the Pages site if the repository does not have one.
+      #
+      # Without it this step fails "Get Pages site failed ... verify that the repository has Pages enabled",
+      # which is what both runs of this workflow did on 2026-07-16 — the only two it has ever had. Pages had
+      # never been switched on, so the workflow was correct and had nothing to deploy to. Setting it here
+      # means running this workflow is sufficient: no Settings visit, and it self-heals if the site is ever
+      # removed.
+      #
+      # The custom domain still comes from website/CNAME (capstead.ai), which travels with the uploaded
+      # artifact. DNS is the one part no workflow can do: the apex needs A/AAAA records pointing at GitHub
+      # Pages, and www a CNAME to the github.io host.
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload website artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
One line, so the workflow can create the Pages site it deploys to.

## Why it has never worked

`pages.yml` has run **twice**, both on 2026-07-16, and failed both times. Those are the only runs it has ever had — the website has never deployed, so this is not a recent regression.

The workflow was not the problem. Pages was never switched on for the repository:

```
$ gh api repos/satya-anguluri/capstead/pages
{"message":"Not Found", "status":"404"}
```

which is precisely what `actions/configure-pages@v5` reports:

> Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions, or consider exploring the `enablement` parameter for this action.

## The change

`enablement: true`, which is the parameter that error message points at. The action creates the site when it is missing, so **running the workflow is now sufficient** — no Settings visit in the loop, and it self-heals if the site is ever removed.

Left alone because they were already correct: the `permissions` block (`pages: write`, `id-token: write`), the `github-pages` environment, and `website/CNAME`, which carries `capstead.ai` along with the uploaded artifact.

## How to run it

`workflow_dispatch` is already on this workflow, but **it has to be on `main` before the button appears** — GitHub only offers manual dispatch for workflows on the default branch. So this needs merging first, then:

Actions → *Deploy website to GitHub Pages* → **Run workflow**

## Two things this cannot do

**DNS.** The apex `capstead.ai` needs A/AAAA records pointing at GitHub Pages, and `www` a CNAME to the `github.io` host. Until those resolve, the deploy will succeed while the domain does not serve. Worth checking the current record set against GitHub's Pages docs rather than any list from memory.

**Guarantee enablement succeeds.** Creating a Pages site is a different API call from deploying to one, and if the token is not permitted to make it the step will fail with a 403 rather than a 404. In that case it has to be enabled once under Settings → Pages with source "GitHub Actions" — after which every run works either way. I would rather say this up front than have it look like the fix silently didn't take.

## Unrelated, noted while here

`actions/checkout@v4` and `actions/configure-pages@v5` both target Node 20, which GitHub has deprecated and is already force-running on Node 24. Not changed here — version bumps on a workflow that has never succeeded are two variables at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
