### PR TITLE
fix(site): the domain is capstead.io — CNAME, links and the hosting runbook

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,7 @@ jobs:
       # means running this workflow is sufficient: no Settings visit, and it self-heals if the site is ever
       # removed.
       #
-      # The custom domain still comes from website/CNAME (capstead.ai), which travels with the uploaded
+      # The custom domain still comes from website/CNAME (capstead.io), which travels with the uploaded
       # artifact. DNS is the one part no workflow can do: the apex needs A/AAAA records pointing at GitHub
       # Pages, and www a CNAME to the github.io host.
       - name: Configure Pages

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Capstead is **not** another AI framework. It's the governance layer that sits *a
 
 > Spring AI tells you about one model invocation. Capstead tells you about the **business capability**: how often it ran, which model it used, how many tokens it consumed, how much it cost, whether it succeeded, and which version executed.
 
-📖 **[Read the research: Governing AI capabilities in Spring Boot →](https://capstead.ai/research)**
+📖 **[Read the research: Governing AI capabilities in Spring Boot →](https://capstead.io/research)**
 
 ---
 

--- a/website/CNAME
+++ b/website/CNAME
@@ -1,1 +1,1 @@
-capstead.ai
+capstead.io

--- a/website/README.md
+++ b/website/README.md
@@ -1,13 +1,13 @@
 # Capstead website
 
-The public site for [capstead.ai](https://capstead.ai). Plain static HTML/CSS — **no build step**.
+The public site for [capstead.io](https://capstead.io). Plain static HTML/CSS — **no build step**.
 
 ```
 website/
   styles.css          # shared theme (mirrors the /capstead dashboard palette)
-  index.html          # landing page              -> capstead.ai/
+  index.html          # landing page              -> capstead.io/
   research/
-    index.html        # governance research page  -> capstead.ai/research
+    index.html        # governance research page  -> capstead.io/research
 ```
 
 ## Preview locally
@@ -27,21 +27,35 @@ Links use absolute root paths (`/`, `/research/`), so serve from the site root (
 Pick either; both serve the folder as-is.
 
 ### Option A — GitHub Pages (current setup)
-This repo already deploys `website/` via `.github/workflows/pages.yml`, and `website/CNAME` pins
-`capstead.ai`. To finish:
-1. Repo **Settings → Pages → Source: GitHub Actions** (unlocks the workflow).
-2. DNS at your registrar:
-   - **Apex `capstead.ai`** → four `A` records: `185.199.108.153`, `185.199.109.153`,
-     `185.199.110.153`, `185.199.111.153` (or an `ALIAS`/`ANAME` → `satya-anguluri.github.io`).
-   - **`www.capstead.ai`** → `CNAME` → `satya-anguluri.github.io`. GitHub Pages auto-redirects the
-     non-canonical host to the apex named in `CNAME`, so `www` → `capstead.ai` works out of the box.
-3. Enable **Enforce HTTPS** once the certificate provisions (a few minutes after DNS resolves).
+This repo deploys `website/` via `.github/workflows/pages.yml`, and `website/CNAME` pins `capstead.io`.
+
+**Nothing has deployed yet.** The workflow has only ever run on 2026-07-16 and after the domain fix, and it
+fails at `Configure Pages` because the repository has no Pages site. The workflow passes `enablement: true`,
+which asks the action to create one, and GitHub refuses it: *"Create Pages site failed. Resource not
+accessible by integration."* Creating a Pages site needs admin credentials, which `GITHUB_TOKEN` is not,
+whatever `pages: write` suggests. So step 1 is genuinely manual, once.
+
+1. Repo **Settings → Pages → Source: GitHub Actions**. After this the workflow can run; `enablement: true`
+   becomes a no-op because the site already exists, and it self-heals if the site is ever deleted.
+2. **DNS at GoDaddy**, which currently serves a Website Builder placeholder on the apex — that has to be
+   detached first, or GoDaddy keeps reasserting its own records:
+   - **Apex `capstead.io`** → four `A` records pointing at GitHub Pages (or an `ALIAS`/`ANAME` →
+     `satya-anguluri.github.io`). Take the current addresses from GitHub's Pages documentation rather than
+     from here — a stale IP list in a README is worse than no list, because it looks authoritative.
+   - **`www.capstead.io`** → `CNAME` → `satya-anguluri.github.io`. Pages redirects the non-canonical host
+     to the apex named in `CNAME`, so `www` → `capstead.io` works without a second rule.
+3. Add the **domain-verification `TXT`** record offered in Settings → Pages. An unverified custom domain
+   pointed at Pages can be claimed by another account.
+4. Enable **Enforce HTTPS** once the certificate provisions — minutes to an hour after DNS resolves.
+
+A green workflow run says nothing about whether the domain serves: the deploy and the DNS are independent,
+and a passing deploy with a dead domain is what a DNS problem looks like.
 
 ### Option B — S3 + CloudFront (matches the existing EngineerPrep setup)
 1. `aws s3 sync website/ s3://<bucket> --delete`
 2. CloudFront distribution with the bucket as origin; default root object `index.html`.
 3. Add a subdirectory-index behavior (Function/Lambda@Edge) so `/research/` resolves to
-   `/research/index.html`, then point `capstead.ai` at the distribution and invalidate `/*`.
+   `/research/index.html`, then point `capstead.io` at the distribution and invalidate `/*`.
 
 ## Editing
 


### PR DESCRIPTION
`website/CNAME` said `capstead.ai`, so every deploy would set the custom domain to a domain that **does not exist**:

```
$ nslookup capstead.ai 8.8.8.8   →  Non-existent domain
$ nslookup capstead.ai 1.1.1.1   →  Non-existent domain
$ curl https://capstead.ai       →  HTTP 000
```

No nameservers in the registry at all. `capstead.io` is the registered domain, currently serving a GoDaddy Website Builder placeholder. The README's research link was dead for anyone who clicked it.

## Not a find-and-replace, and this is the part worth reading

`capstead.ai` also appears as a **Spring configuration prefix** — `@ConfigurationProperties("capstead.ai")`, `capstead.ai.profiles.<name>` — in `ModelProfile`, `ModelProfileProperties`, `DECLARATIVE-CAPABILITIES.md`, `QuizCapability`, the knowledge base and a video script.

That is a property namespace, not a domain. Renaming it would break every consumer's YAML in a patch release. **Those nine occurrences are deliberately untouched.** Only the four that are URLs or the CNAME changed:

| File | Change |
|---|---|
| `website/CNAME` | `capstead.ai` → `capstead.io` (LF-terminated, verified — a trailing `\r` would make the domain unparseable) |
| `README.md` | the research link |
| `website/README.md` | site description, the two path examples, and the hosting runbook |
| `.github/workflows/pages.yml` | a comment I wrote in the previous PR |

## The runbook was rewritten, not search-replaced

It documented steps that are no longer true. It said Settings → Pages "unlocks the workflow" as step one of three. What actually happens now, confirmed on the run that fired when #18 merged:

```
Get Pages site failed.    Error: Not Found
Create Pages site failed. Error: Resource not accessible by integration
```

So `enablement: true` *does* ask for the site and GitHub refuses — creating a Pages site needs admin credentials that `GITHUB_TOKEN` does not have, whatever `pages: write` implies. The manual step is unavoidable, and the runbook now says so instead of implying the workflow handles it.

Three other corrections in there:

- **GoDaddy's placeholder has to be detached** before apex records will hold, or it keeps reasserting its own.
- **The domain-verification `TXT` record** is now called out — an unverified custom domain pointed at Pages can be claimed by another account.
- **The hard-coded GitHub Pages IP list is gone**, replaced by a pointer to GitHub's own docs. A stale IP list in a README is worse than none, because it reads as authoritative.

It also now states plainly that a green workflow run says nothing about whether the domain serves — the deploy and the DNS are independent, and a passing deploy with a dead domain is exactly what a DNS problem looks like.

## Verification

`mvn -B -ntp clean verify` — **82 tests, 0 failures**. No code changed; the build is what confirms the config prefix was left alone.

## Still needs you, in order

1. **Settings → Pages → Source: GitHub Actions** — the step the token cannot do
2. DNS at GoDaddy: detach the placeholder, then apex A/AAAA + `www` CNAME
3. The verification TXT record
4. Enforce HTTPS once the certificate provisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
