### PR TITLE
release: 0.8.0 — minor, because a public response shape changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+Notable changes to Capstead. Versions follow `0.MINOR.PATCH` while the library is pre-1.0: a **minor** bump
+may change behaviour or a public shape, a **patch** never does.
+
+## 0.8.0
+
+### Breaking
+
+- **`GET /actuator/capabilityexecutions/{id}` nests to full depth, and its `children` array changed shape.**
+
+  ```diff
+  -{ "execution": { … }, "children": [ { … }, { … } ] }
+  +{ "execution": { … }, "children": [ { "execution": { … }, "children": [ … ] } ] }
+  ```
+
+  `children` now holds `ExecutionTree` objects rather than `CapabilityExecutionView` objects, so a consumer
+  reading `children[].executionId` must read `children[].execution.executionId` instead.
+
+  The response type has always been called `ExecutionTree` and previously returned one execution plus its
+  **direct** children. A capability that called a capability that called another reported the middle layer and
+  stopped, so a caller who did not know to walk it themselves received a complete-looking answer that was
+  missing everything below depth one. The type now matches its name.
+
+  An unknown or aged-out id still returns `null`, so callers already handling that case are unaffected.
+
+- **`CapabilityExecutionQuery` gained `subtree(String executionId)`.** Any third-party implementation of that
+  interface will not compile until it implements the new method. Both bundled implementations
+  (`InMemoryCapabilityExecutionStore`, `JdbcCapabilityExecutionReader`) do.
+
+### Added
+
+- **`subtree(executionId)` — a whole execution tree in one call.** `childrenOf` answers a single level;
+  reassembling a tree from it cost a round trip per level and left every caller writing the same traversal.
+  In-memory this is one pass to index by parent then a breadth-first walk; over JDBC it is a recursive CTE,
+  exercised against both H2 and MySQL 8.
+
+  Ordering is part of the contract: the root comes first and every node appears after its own parent, so a
+  consumer can build the nested shape in a single pass with no sorting and no second index. Siblings are
+  most-recent-first, tie-broken on execution id so that executions recorded in the same millisecond — a
+  capability fanning out to several tools does exactly that — still come back in a fixed order. Both
+  implementations produce the same order, and a test asserts the property rather than a fixed list.
+
+  Malformed graphs are bounded rather than fatal. Nothing validates that parent links form a tree, so a
+  record whose ancestor claims it as a parent would otherwise loop forever on a read path serving an actuator
+  endpoint: the in-memory store tracks visited ids, the CTE bounds depth at 50, and each returns a truncated
+  tree instead of hanging. A duplicated id cannot detach already-attached children from the nested response.
+
+- **A build.** `mvn -B -ntp verify` now runs on every pull request and push to `main`, on a runner with
+  Docker, so the MySQL Testcontainers round-trips actually execute. They are
+  `@Testcontainers(disabledWithoutDocker = true)` and therefore *skip* on a machine without a daemon, which
+  meant a green local run could be several tests that never ran. The build reports totals and names any suite
+  that skipped.
+
+### Fixed
+
+- **Test isolation in `JdbcCapabilityExecutionRoundTripTest`.** Every test opened the same H2 in-memory
+  database under its default name and none closed it, so rows leaked between tests. Harmless while each test
+  used unique ids, and the sort of failure that passes alone and fails together.
+
+### Not included
+
+`subtree` returns the same `CapabilityExecution` records the rest of `CapabilityExecutionQuery` returns
+rather than a new export type. An export shape that consumers persist and diff is a contract worth settling
+once, alongside the ordered execution events it will need to carry, so `findByAttribute` and a versioned
+export shape remain open.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Modern apps expose AI capabilities across many services and teams, and nobody ca
 <dependency>
     <groupId>io.capstead</groupId>
     <artifactId>capstead-starter</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
 </dependency>
 ```
 
@@ -158,7 +158,7 @@ Capstead does **not** measure tokens itself — it *attributes* Spring AI's exis
 <dependency>
     <groupId>io.capstead</groupId>
     <artifactId>capstead-spring-ai</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
 </dependency>
 ```
 
@@ -204,7 +204,7 @@ The in-memory store is bounded and per-instance. Add `capstead-jdbc` to persist 
 <dependency>
     <groupId>io.capstead</groupId>
     <artifactId>capstead-jdbc</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
 </dependency>
 ```
 
@@ -229,7 +229,7 @@ Capstead can publish your governed capabilities as [Model Context Protocol](http
 <dependency>
     <groupId>io.capstead</groupId>
     <artifactId>capstead-mcp</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
 </dependency>
 ```
 
@@ -251,7 +251,7 @@ To expose the tools over a real MCP transport (STDIO, SSE, Streamable-HTTP), add
 <dependency>
     <groupId>io.capstead</groupId>
     <artifactId>capstead-mcp-server</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
 </dependency>
 <dependency>
     <groupId>org.springframework.ai</groupId>
@@ -375,7 +375,7 @@ flowchart TB
 
 ## Status
 
-`0.7.0`. The open-source core is complete and tested: registry, metadata, versioning, discovery, first-class executions with **per-model invocations and parent-child execution trees**, cost estimation, daily budgets, actuator endpoints (catalog, scorecard, metrics, **execution history**), a dashboard, the Spring AI bridge, **provider-neutral declarative capabilities** (`@CapabilityClient` — works with any model backend via a `CapabilityModelInvoker`), MCP export (tool model, actuator, and Spring AI MCP server bridge), and an optional **JDBC recorder** for durable, cross-instance history with retention.
+`0.8.0`. The open-source core is complete and tested: registry, metadata, versioning, discovery, first-class executions with **per-model invocations and parent-child execution trees**, cost estimation, daily budgets, actuator endpoints (catalog, scorecard, metrics, **execution history**), a dashboard, the Spring AI bridge, **provider-neutral declarative capabilities** (`@CapabilityClient` — works with any model backend via a `CapabilityModelInvoker`), MCP export (tool model, actuator, and Spring AI MCP server bridge), and an optional **JDBC recorder** for durable, cross-instance history with retention.
 
 ## License
 

--- a/capstead-annotations/pom.xml
+++ b/capstead-annotations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.capstead</groupId>
         <artifactId>capstead-parent</artifactId>
-        <version>0.7.0</version>
+        <version>0.8.0</version>
     </parent>
 
     <artifactId>capstead-annotations</artifactId>

--- a/capstead-core/pom.xml
+++ b/capstead-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.capstead</groupId>
         <artifactId>capstead-parent</artifactId>
-        <version>0.7.0</version>
+        <version>0.8.0</version>
     </parent>
 
     <artifactId>capstead-core</artifactId>

--- a/capstead-jdbc/pom.xml
+++ b/capstead-jdbc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.capstead</groupId>
         <artifactId>capstead-parent</artifactId>
-        <version>0.7.0</version>
+        <version>0.8.0</version>
     </parent>
 
     <artifactId>capstead-jdbc</artifactId>

--- a/capstead-mcp-server/pom.xml
+++ b/capstead-mcp-server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.capstead</groupId>
         <artifactId>capstead-parent</artifactId>
-        <version>0.7.0</version>
+        <version>0.8.0</version>
     </parent>
 
     <artifactId>capstead-mcp-server</artifactId>

--- a/capstead-mcp/pom.xml
+++ b/capstead-mcp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.capstead</groupId>
         <artifactId>capstead-parent</artifactId>
-        <version>0.7.0</version>
+        <version>0.8.0</version>
     </parent>
 
     <artifactId>capstead-mcp</artifactId>

--- a/capstead-runtime/pom.xml
+++ b/capstead-runtime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.capstead</groupId>
         <artifactId>capstead-parent</artifactId>
-        <version>0.7.0</version>
+        <version>0.8.0</version>
     </parent>
 
     <artifactId>capstead-runtime</artifactId>

--- a/capstead-spring-ai/pom.xml
+++ b/capstead-spring-ai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.capstead</groupId>
         <artifactId>capstead-parent</artifactId>
-        <version>0.7.0</version>
+        <version>0.8.0</version>
     </parent>
 
     <artifactId>capstead-spring-ai</artifactId>

--- a/capstead-starter/pom.xml
+++ b/capstead-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.capstead</groupId>
         <artifactId>capstead-parent</artifactId>
-        <version>0.7.0</version>
+        <version>0.8.0</version>
     </parent>
 
     <artifactId>capstead-starter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.capstead</groupId>
     <artifactId>capstead-parent</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
     <packaging>pom</packaging>
 
     <name>Capstead Parent</name>

--- a/website/README.md
+++ b/website/README.md
@@ -61,4 +61,4 @@ and a passing deploy with a dead domain is what a DNS problem looks like.
 
 - Colors/spacing live in `styles.css` (`:root` variables mirror the dashboard).
 - The comparison table and case-study numbers in `research/index.html` are first-party; keep them
-  accurate to the current release when bumping versions (currently `0.5.3`).
+  accurate to the current release when bumping versions (currently `0.8.0`).


### PR DESCRIPTION
Prepares `0.8.0`. **Does not publish** — that stays a human step, see the bottom.

## Why a release is needed at all

`0.7.0` is already on Maven Central:

```
io.capstead:capstead-starter   latest = 0.7.0   release = 0.7.0
```

So the pom and all five README install snippets were naming the **published** version rather than the next one. Anyone copying the snippet today gets a build without the subtree work in it.

## Why minor, not patch

Two changes in this release are incompatible, and a patch would have signalled neither:

1. **`GET /actuator/capabilityexecutions/{id}` nests to full depth.** `children` holds trees rather than executions, so a consumer reading `children[].executionId` must read `children[].execution.executionId`.
2. **`CapabilityExecutionQuery` gained `subtree()`.** Any third-party implementation of that interface stops compiling.

## What was deliberately *not* bumped

This is the part a mechanical find-and-replace would have got wrong, so it is worth listing:

| Reference | Left alone because |
|---|---|
| `README.md:187` "In `0.7.0` the recorder became durable and structured" | History. Rewriting it claims a 0.7.0 feature arrived in 0.8.0. |
| `docs/LAUNCH.md` (`0.3.0`, 11 times) | A worked example of *how to announce a release*, not a version claim. |
| `docs/launch-article.md` (`0.3.1`) | A published article draft, pinned to what it shipped with. |
| `DECLARATIVE-CAPABILITIES.md` "provider-neutral since `0.5.0`" | A true statement about when that happened. |

One that *was* genuinely stale and is fixed: `website/README.md` claimed "currently `0.5.3`" — on a document that now publishes to `capstead.io`.

## CHANGELOG.md

Added, because there wasn't one. For a library whose entire pitch is governance and auditability, shipping a silent response-shape change would be a poor advertisement. It states the diff, explains why the old shape was wrong (the type was *called* `ExecutionTree` and returned one level, so a caller who didn't know to walk it got a complete-looking answer missing everything below depth one), and records what was deliberately left out — `findByAttribute` and a versioned export shape, which want the ordered-events work first.

## Verification

`mvn -B -ntp clean verify` — **82 tests, 0 failures**, artifacts built as `capstead-*-0.8.0.jar`. The 3 skips are the Docker-gated MySQL round-trips, which CI runs on the runner.

## Releasing is manual, and stays that way

`maven-gpg-plugin` and `central-publishing-maven-plugin` are configured in the root pom **outside any profile**, and no workflow publishes. So the release mechanism is `mvn deploy` from a machine holding your signing key and Central credentials.

I have not run it and would not: publishing to Central is irreversible, and a version cannot be replaced once it is out. Suggested order once this merges:

1. `mvn -B clean verify` on `main` at the merge commit
2. `mvn deploy` with your credentials
3. Confirm `https://repo1.maven.org/maven2/io/capstead/capstead-starter/0.8.0/` returns the pom
4. Cut a GitHub Release for `v0.8.0`, pointing at the CHANGELOG entry — `docs/LAUNCH.md` step 29 already asks for this and it has never been done for a release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
