### PR TITLE
docs(site): stop claiming the workflow can recreate a Pages site it c…

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,13 +28,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # enablement: true creates the Pages site if the repository does not have one.
+      # enablement: true asks the action to create the Pages site when the repository has none.
       #
-      # Without it this step fails "Get Pages site failed ... verify that the repository has Pages enabled",
-      # which is what both runs of this workflow did on 2026-07-16 — the only two it has ever had. Pages had
-      # never been switched on, so the workflow was correct and had nothing to deploy to. Setting it here
-      # means running this workflow is sufficient: no Settings visit, and it self-heals if the site is ever
-      # removed.
+      # It does NOT remove the need for a person to enable Pages once. GITHUB_TOKEN is refused with
+      # "Create Pages site failed. Resource not accessible by integration" — creating a site needs admin
+      # credentials the workflow token does not have, whatever pages: write suggests. So the first
+      # enablement is manual: Settings -> Pages -> Source: GitHub Actions.
+      #
+      # It is kept because it costs nothing and turns the "no site" case into one clear error instead of a
+      # 404 from the lookup, and because the parameter is what the failure message itself points at.
       #
       # The custom domain still comes from website/CNAME (capstead.io), which travels with the uploaded
       # artifact. DNS is the one part no workflow can do: the apex needs A/AAAA records pointing at GitHub

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Capstead is **not** another AI framework. It's the governance layer that sits *a
 
 > Spring AI tells you about one model invocation. Capstead tells you about the **business capability**: how often it ran, which model it used, how many tokens it consumed, how much it cost, whether it succeeded, and which version executed.
 
-📖 **[Read the research: Governing AI capabilities in Spring Boot →](https://capstead.io/research)**
+📖 **[Read the research: Governing AI capabilities in Spring Boot →](https://capstead.io/research/)**
 
 ---
 

--- a/website/README.md
+++ b/website/README.md
@@ -7,7 +7,7 @@ website/
   styles.css          # shared theme (mirrors the /capstead dashboard palette)
   index.html          # landing page              -> capstead.io/
   research/
-    index.html        # governance research page  -> capstead.io/research
+    index.html        # governance research page  -> capstead.io/research/
 ```
 
 ## Preview locally
@@ -29,14 +29,15 @@ Pick either; both serve the folder as-is.
 ### Option A — GitHub Pages (current setup)
 This repo deploys `website/` via `.github/workflows/pages.yml`, and `website/CNAME` pins `capstead.io`.
 
-**Nothing has deployed yet.** The workflow has only ever run on 2026-07-16 and after the domain fix, and it
-fails at `Configure Pages` because the repository has no Pages site. The workflow passes `enablement: true`,
-which asks the action to create one, and GitHub refuses it: *"Create Pages site failed. Resource not
+**A person has to enable Pages once; the workflow cannot do it.** The workflow passes `enablement: true`,
+which asks the action to create the site, and GitHub refuses: *"Create Pages site failed. Resource not
 accessible by integration."* Creating a Pages site needs admin credentials, which `GITHUB_TOKEN` is not,
-whatever `pages: write` suggests. So step 1 is genuinely manual, once.
+whatever `pages: write` suggests. Deploying to an existing site is a different call, and that one works —
+which is why the workflow is otherwise correct and has simply never had a site to deploy to.
 
-1. Repo **Settings → Pages → Source: GitHub Actions**. After this the workflow can run; `enablement: true`
-   becomes a no-op because the site already exists, and it self-heals if the site is ever deleted.
+1. Repo **Settings → Pages → Source: GitHub Actions**. After this the workflow runs on its own, and
+   `enablement: true` becomes a no-op because the site already exists. If the site is ever deleted, this
+   step has to be repeated by hand for the same reason.
 2. **DNS at GoDaddy**, which currently serves a Website Builder placeholder on the apex — that has to be
    detached first, or GoDaddy keeps reasserting its own records:
    - **Apex `capstead.io`** → four `A` records pointing at GitHub Pages (or an `ALIAS`/`ANAME` →


### PR DESCRIPTION
…annot create

Four review findings, all valid, and two of them catch the same contradiction in two files.

The workflow comment I wrote in #18 said enablement: true means "no Settings visit" and that it "self-heals if the site is ever removed". Both were written before the 403 was observed, and neither survived it: GITHUB_TOKEN is refused with "Create Pages site failed. Resource not accessible by integration", so the workflow cannot create a site the first time OR after a deletion. website/README.md was updated when we learned that and the workflow comment was not, so the repository stated both things at once.

The runbook carried the same claim in its step 1 while its own preceding paragraph explained why the token cannot do it. Rewritten to say the manual step recurs if the site is ever deleted, for exactly the same reason.

enablement: true stays. It costs nothing, it is the parameter the failure message itself points at, and it turns the no-site case into one clear error rather than a 404 from the lookup.

The runbook also opened with how many times the workflow had run and on which date, which is history rather than guidance and stops being true the moment it runs again. Replaced with the durable statement.

And both READMEs linked capstead.io/research where the site links /research/ — six hrefs in index.html and research/index.html all use the trailing slash. Linking without it relies on a redirect to reach the site's own canonical path.

Verification: mvn -B -ntp clean verify — 82 tests, 0 failures. Documentation and one workflow comment only.