### PR TITLE
fix(site): the published version, on the pages that tell people to install it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Confirm Docker is available for Testcontainers
         run: docker version --format 'Docker {{.Server.Version}}, API {{.Server.APIVersion}}'
 
+      # Cheap, and it runs BEFORE the build so a version mistake fails in ten seconds rather than after the
+      # full suite. The website served 0.5.3 for three releases while the pom said 0.8.0; a README asking
+      # people to keep them in step is not a control.
+      - name: Check install snippets and the changelog match the pom
+        run: bash scripts/check-versions.sh
+
       - name: Build and test
         run: mvn -B -ntp verify
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,179 @@
+name: Publish to Maven Central
+
+# Staging a release to the Central Portal. Manual only, and guarded, because publishing a version to Central
+# cannot be undone: a version that goes out cannot be replaced, only superseded.
+#
+# WHAT THIS DOES NOT DO. The root pom sets <autoPublish>false</autoPublish>, so this uploads a deployment and
+# leaves it VALIDATED but unpublished in the Central Portal. Someone still has to open the portal and press
+# Publish. That is the safety property worth keeping — this workflow gets the artifacts built, signed and
+# validated by a machine, and leaves the irreversible half to a person.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish. Must match the pom exactly (e.g. 0.8.0).'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never two publishes at once. A half-uploaded deployment is a support ticket with Sonatype.
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Stage ${{ inputs.version }} to Central
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # server-id must match <publishingServerId>central</publishingServerId> in the release profile, or the
+      # plugin looks up credentials under a name settings.xml does not contain and fails as "unauthorized"
+      # rather than as "misconfigured".
+      - name: Set up JDK 17 and Maven credentials
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      # Fail on a missing secret HERE, with a message naming it, rather than 20 minutes later inside Maven.
+      - name: Check the required secrets are present
+        env:
+          U: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          P: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          K: ${{ secrets.GPG_PRIVATE_KEY }}
+          G: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          missing=""
+          [ -z "$U" ] && missing="$missing MAVEN_CENTRAL_USERNAME"
+          [ -z "$P" ] && missing="$missing MAVEN_CENTRAL_PASSWORD"
+          [ -z "$K" ] && missing="$missing GPG_PRIVATE_KEY"
+          [ -z "$G" ] && missing="$missing GPG_PASSPHRASE"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing repository secrets:$missing"
+            echo "MAVEN_CENTRAL_* are a Central Portal user token (Account -> Generate User Token)."
+            echo "GPG_PRIVATE_KEY is an ASCII-armoured secret key: gpg --armor --export-secret-keys <KEYID>"
+            exit 1
+          fi
+          echo "All four secrets present."
+
+      # Three guards, in order of how badly each would end.
+      - name: Verify the version is publishable
+        env:
+          WANTED: ${{ inputs.version }}
+        run: |
+          POM=$(mvn -B -ntp -q help:evaluate -Dexpression=project.version -DforceStdout)
+          echo "pom version:      $POM"
+          echo "requested:        $WANTED"
+
+          # 1. Typing the version by hand is the confirmation step. A mismatch means one of the two is wrong,
+          #    and guessing which would be how the wrong version gets published.
+          if [ "$POM" != "$WANTED" ]; then
+            echo "::error::The pom is at $POM but $WANTED was requested. Bump the pom, or request $POM."
+            exit 1
+          fi
+
+          # 2. A SNAPSHOT cannot go to Central at all, and the failure from the far end is opaque.
+          case "$POM" in
+            *-SNAPSHOT)
+              echo "::error::$POM is a SNAPSHOT. Central does not accept snapshot releases."
+              exit 1;;
+          esac
+
+          # 3. The one that matters. Central versions are immutable, so re-publishing an existing version is
+          #    not a retry — it is a rejected upload at best and a confusing half-state at worst.
+          CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 \
+            "https://repo1.maven.org/maven2/io/capstead/capstead-starter/$POM/")
+          echo "repo1 status for $POM: $CODE"
+          if [ "$CODE" = "200" ]; then
+            echo "::error::$POM is already on Maven Central. Versions there are immutable — bump and retry."
+            exit 1
+          fi
+          echo "$POM is not on Central. Proceeding."
+
+      # Same check the build runs, repeated here on purpose. A release is the one moment the snippets MUST be
+      # right, and this is the last point at which being wrong is still free: a published version cannot be
+      # corrected, only superseded. It also refuses a version with no changelog section, which would mean a
+      # release with no notes, because the notes are extracted from that section.
+      - name: Check install snippets and the changelog match the version being published
+        run: bash scripts/check-versions.sh "${{ inputs.version }}"
+
+      # The notes, produced from the changelog rather than written twice, printed into the run summary so the
+      # exact text is visible before anyone creates a release from it.
+      - name: Preview the release notes
+        run: |
+          {
+            echo "### Release notes for ${{ inputs.version }}"
+            echo ""
+            echo "Extracted from CHANGELOG.md — create the release with:"
+            echo ""
+            echo "    scripts/changelog-section.sh ${{ inputs.version }} > notes.md"
+            echo "    gh release create v${{ inputs.version }} --notes-file notes.md"
+            echo ""
+            echo "---"
+            echo ""
+            bash scripts/changelog-section.sh "${{ inputs.version }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Testcontainers is @Testcontainers(disabledWithoutDocker = true), so without a daemon the MySQL
+      # round-trips SKIP rather than fail. Publishing on a green run that quietly skipped its database tests
+      # is precisely the mistake worth preventing on the one workflow that cannot be undone.
+      - name: Confirm Docker is available for Testcontainers
+        run: docker version --format 'Docker {{.Server.Version}}, API {{.Server.APIVersion}}'
+
+      # ONE command, deliberately. `verify` then `deploy` would run the whole suite twice; `deploy -DskipTests`
+      # would publish artifacts nothing tested. deploy runs the lifecycle once: test, sign, upload.
+      - name: Build, sign and stage to Central
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: mvn -B -ntp -Prelease deploy
+
+      - name: Test summary
+        if: always()
+        run: |
+          if ! ls */target/surefire-reports/*.txt >/dev/null 2>&1; then
+            echo "No surefire reports — the build failed before tests ran."
+            exit 0
+          fi
+          grep -h "Tests run:" */target/surefire-reports/*.txt \
+            | awk -F'[ ,]+' '{t+=$3; f+=$5; e+=$7; s+=$9}
+                             END {printf "total=%d failures=%d errors=%d skipped=%d\n", t, f, e, s}'
+          echo "--- skipped, if any ---"
+          grep -l "Skipped: [1-9]" */target/surefire-reports/*.txt || echo "none"
+
+      - name: What to do next
+        if: success()
+        run: |
+          {
+            echo "### ${{ inputs.version }} is staged, not published"
+            echo ""
+            echo "autoPublish is false, so this deployment is sitting VALIDATED in the Central Portal and"
+            echo "nothing is public yet."
+            echo ""
+            echo "1. Open https://central.sonatype.com/publishing/deployments"
+            echo "2. Check the deployment for io.capstead ${{ inputs.version }}"
+            echo "3. Press **Publish**"
+            echo "4. Confirm https://repo1.maven.org/maven2/io/capstead/capstead-starter/${{ inputs.version }}/ returns 200"
+            echo "   (allow a few minutes for it to sync)"
+            echo "5. Tag and cut a GitHub Release for v${{ inputs.version }}, pointing at the CHANGELOG entry"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: '*/target/surefire-reports/**'
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,15 @@
 Notable changes to Capstead. Versions follow `0.MINOR.PATCH` while the library is pre-1.0: a **minor** bump
 may change behaviour or a public shape, a **patch** never does.
 
+> **This file is the source for GitHub release notes.** `scripts/changelog-section.sh <version>` extracts a
+> section verbatim and `gh release create --notes-file` publishes it, so an entry has to read as notes: open
+> with one line saying what the release gives you, then the categorised detail. Anything written only on the
+> release page will be lost the next time the notes are regenerated.
+
 ## 0.8.0
+
+Walk a whole capability execution tree in one call, and get the actual tree from the actuator instead of one
+level of it.
 
 ### Breaking
 
@@ -64,3 +72,25 @@ may change behaviour or a public shape, a **patch** never does.
 rather than a new export type. An export shape that consumers persist and diff is a contract worth settling
 once, alongside the ordered execution events it will need to carry, so `findByAttribute` and a versioned
 export shape remain open.
+
+### Example
+
+```java
+// Every descendant, ordered root-first, parents before children.
+List<CapabilityExecution> tree = query.subtree(rootExecutionId);
+```
+
+```
+GET /actuator/capabilityexecutions/{id}
+{
+  "execution": { "capabilityName": "Generate Course", "executionId": "exec-1", … },
+  "children": [
+    { "execution": { "capabilityName": "Generate Lesson", … },
+      "children": [ { "execution": { "capabilityName": "Score Lesson", … }, "children": [] } ] }
+  ]
+}
+```
+
+---
+
+`io.capstead:capstead-starter:0.8.0` · [Maven Central](https://repo1.maven.org/maven2/io/capstead/capstead-starter/0.8.0/)

--- a/scripts/changelog-section.sh
+++ b/scripts/changelog-section.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Print one version's section of CHANGELOG.md, for use as GitHub release notes.
+#
+#   scripts/changelog-section.sh 0.8.0 > notes.md
+#   gh release create v0.8.0 --notes-file notes.md
+#
+# WHY THIS EXISTS. The 0.8.0 release notes and the 0.8.0 changelog entry were written separately, said
+# overlapping things, and would have drifted the moment either was edited. The changelog is the source now and
+# the release page is a projection of it — so there is one place to write and one thing to keep true.
+#
+# The cost is that CHANGELOG.md has to read well as release notes, which means a one-line summary under the
+# version heading before the categorised sections rather than diving straight into "### Breaking".
+#
+# Boundaries are "## <version>" to the next "## " at the same level. "### " subsections are part of the
+# section, which is why the terminator is anchored to exactly two hashes followed by a space.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  echo "usage: $(basename "$0") <version>" >&2
+  exit 2
+fi
+
+if [ ! -f CHANGELOG.md ]; then
+  echo "CHANGELOG.md not found" >&2
+  exit 1
+fi
+
+# -v so the version is a literal, not a regex: dots in 0.8.0 would otherwise match 0x8y0.
+section=$(awk -v want="$VERSION" '
+  # Exactly "## <version>", with nothing else on the line but optional trailing space.
+  $0 == "## " want { inside = 1; next }
+  # A following top-level heading ends it. "### " does not.
+  inside && /^## / { exit }
+  inside { print }
+' CHANGELOG.md)
+
+# Trim leading and trailing blank lines, so the notes do not open or close with whitespace.
+section=$(printf '%s\n' "$section" | sed -e '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba')
+
+if [ -z "$section" ]; then
+  echo "No '## $VERSION' section in CHANGELOG.md." >&2
+  echo "Sections present:" >&2
+  grep -E '^## ' CHANGELOG.md >&2 || true
+  exit 1
+fi
+
+printf '%s\n' "$section"

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Does every version a reader is told to install match the version this repo builds?
+#
+# The website served 0.5.3 for three releases while the pom said 0.8.0, and website/README.md had carried the
+# instruction to keep them in step the whole time. An instruction that relies on someone remembering to grep
+# is not a control, which is what this replaces.
+#
+# WHAT IT DELIBERATELY IGNORES, and this is the part that decides whether the check survives contact:
+# historical version references are CORRECT and must never be rewritten. README.md says "In 0.7.0 the recorder
+# became durable", docs/LAUNCH.md uses 0.3.0 eleven times as a worked example of announcing a release, and
+# DECLARATIVE-CAPABILITIES.md says "provider-neutral since 0.5.0". A check that flagged those would be
+# switched off within a week and the repo would be worse off than with no check at all.
+#
+# So it looks at exactly one thing: a <version> that sits inside a capstead-starter dependency block — the
+# snippet someone copies. Plain XML in Markdown, HTML-escaped in the site's <pre> blocks.
+#
+# Usage: scripts/check-versions.sh [expected-version]
+#        With no argument it asks Maven for the project version.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+EXPECTED="${1:-}"
+if [ -z "$EXPECTED" ]; then
+  EXPECTED=$(mvn -B -ntp -q help:evaluate -Dexpression=project.version -DforceStdout)
+fi
+echo "expected version: $EXPECTED"
+
+FILES="README.md website/index.html website/research/index.html"
+fail=0
+
+for f in $FILES; do
+  [ -f "$f" ] || { echo "::warning::$f not found, skipping"; continue; }
+
+  # Every line mentioning the starter artifact, then the version within the following three lines. Printed as
+  # "file:line:version" so a failure names the exact place to edit.
+  found=$(awk -v file="$f" '
+    # ANY capstead-* artifact, not just the starter: the README also installs capstead-spring-ai,
+    # capstead-jdbc, capstead-mcp and capstead-mcp-server, and all four go stale the same way. The
+    # capstead- prefix is what excludes spring-ai-starter-mcp-server, which carries the Spring AI
+    # version and must never be rewritten to ours.
+    /capstead-[a-z-]*<\/artifactId>|capstead-[a-z-]*&lt;\/artifactId&gt;/ { hot = 3; next }
+    hot > 0 {
+      line = $0
+      gsub(/&lt;/, "<", line); gsub(/&gt;/, ">", line)
+      if (match(line, /<version>[^<]+<\/version>/)) {
+        v = substr(line, RSTART, RLENGTH)
+        gsub(/<\/?version>/, "", v)
+        gsub(/^[ \t]+|[ \t]+$/, "", v)
+        print file ":" NR ":" v
+        hot = 0
+        next
+      }
+      hot--
+    }' "$f")
+
+  if [ -z "$found" ]; then
+    echo "::warning::$f mentions no capstead-starter dependency block"
+    continue
+  fi
+
+  while IFS= read -r hit; do
+    v="${hit##*:}"
+    if [ "$v" = "$EXPECTED" ]; then
+      echo "  ok   $hit"
+    else
+      echo "::error::$hit declares $v but this repo builds $EXPECTED"
+      fail=1
+    fi
+  done <<< "$found"
+done
+
+# A release with no changelog entry is a release nobody can read. Cheap to assert, and it is the one thing
+# about the CHANGELOG that can be checked mechanically — its contents cannot be.
+if [ ! -f CHANGELOG.md ]; then
+  echo "::error::CHANGELOG.md is missing"
+  fail=1
+elif grep -qE "^## +${EXPECTED}([[:space:]]|$)" CHANGELOG.md; then
+  echo "  ok   CHANGELOG.md has a section for $EXPECTED"
+else
+  echo "::error::CHANGELOG.md has no '## $EXPECTED' section"
+  echo "Release notes are extracted from that section, so without it a release has no notes either."
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo ""
+  echo "Version drift. Update the install snippets and the changelog, NOT the historical mentions:"
+  echo "  README.md          'In 0.7.0 the recorder became ...'      <- correct, leave it"
+  echo "  docs/LAUNCH.md     0.3.0 as a worked example              <- correct, leave it"
+  echo "  DECLARATIVE-*.md   'provider-neutral since 0.5.0'         <- correct, leave it"
+  exit 1
+fi
+
+echo "All install snippets and the changelog agree on $EXPECTED."

--- a/website/index.html
+++ b/website/index.html
@@ -119,7 +119,7 @@ class LessonService {
 <pre><code>&lt;dependency&gt;
     &lt;groupId&gt;io.capstead&lt;/groupId&gt;
     &lt;artifactId&gt;capstead-starter&lt;/artifactId&gt;
-    &lt;version&gt;0.5.3&lt;/version&gt;
+    &lt;version&gt;0.8.0&lt;/version&gt;
 &lt;/dependency&gt;</code></pre>
     <p class="muted" style="margin-top:14px">
         Then open the dashboard at <code>/capstead</code> and hit <code>/actuator/capabilityscorecard</code>.

--- a/website/research/index.html
+++ b/website/research/index.html
@@ -27,7 +27,7 @@
         them, which version is live, and what each one costs. This is a first-party analysis of that gap and how
         Capstead closes it, native to the Spring Boot runtime.
     </p>
-    <p class="muted" style="margin-top:14px;font-size:14px">Last updated July 2026 · Capstead 0.5.3</p>
+    <p class="muted" style="margin-top:14px;font-size:14px">Last updated July 2026</p>
 </header>
 
 <section class="section wrap">
@@ -220,7 +220,7 @@ public interface LessonCapability {
 <pre><code>&lt;dependency&gt;
     &lt;groupId&gt;io.capstead&lt;/groupId&gt;
     &lt;artifactId&gt;capstead-starter&lt;/artifactId&gt;
-    &lt;version&gt;0.5.3&lt;/version&gt;
+    &lt;version&gt;0.8.0&lt;/version&gt;
 &lt;/dependency&gt;</code></pre>
     <div class="cta" style="margin-top:22px;display:flex;gap:12px;flex-wrap:wrap">
         <a class="btn primary" href="https://github.com/satya-anguluri/capstead">View the source</a>


### PR DESCRIPTION
The live site told visitors to add `0.5.3` — three versions behind, and behind the release that just shipped.

**My miss.** When preparing 0.8.0 I swept the poms and the markdown docs for version strings and did not grep `website/*.html`, so the two install snippets a reader actually copies were the ones left stale. `website/README.md` even carries the instruction to keep these "accurate to the current release when bumping versions" — the instruction existed and my sweep did not cover the files it referred to.

## Three references, two treatments

| Location | Was | Now | Why |
|---|---|---|---|
| `website/index.html:122` | `0.5.3` | `0.8.0` | Install snippet — a copy-paste resolving to a superseded release |
| `website/research/index.html:223` | `0.5.3` | `0.8.0` | Same |
| `website/research/index.html:30` | "Last updated July 2026 · Capstead 0.5.3" | "Last updated July 2026" | Dates the **analysis**, not an instruction |

That third one is the judgement call. Bumping the number there would claim the research write-up had been re-reviewed against 0.8.0, and it has not been. Removing the version pairing keeps the date honest, loses nothing (the install snippet further down the same page carries the current version), and stops that line going stale every release.

## Note for next time

The version now lives in the poms, five README snippets, `website/README.md` and two site snippets, drifting independently in all of them. This is the second version correction in a single release, which suggests the sweep wants to be a check rather than a habit.

Deploys on merge — `pages.yml` triggers on pushes touching `website/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)